### PR TITLE
Add local storage

### DIFF
--- a/test-app/src/commandParser.js
+++ b/test-app/src/commandParser.js
@@ -104,6 +104,7 @@ export async function runCommand(string, consoleLogQueue = []) {
       await traverseTree(statement);
       lineNumber += 1;
     }
+    lineNumber -= 1;
 
     function delay(time) {
       return new Promise((resolve) => setTimeout(resolve, time));
@@ -112,7 +113,7 @@ export async function runCommand(string, consoleLogQueue = []) {
     await delay(10);
 
     for (const consoleLog of consoleLogQueue) {
-      if (consoleLog.method === "error") {
+      if (consoleLog.method === "error" && !consoleLog.seen) {
         consoleLog.seen = true;
         throw Error(
           `Error printed to console.error. This error occured asynchronously, and may have happened before this line was executed.\n\n${consoleLog.arguments[0]}`

--- a/test-app/src/testingUtil.js
+++ b/test-app/src/testingUtil.js
@@ -97,7 +97,6 @@ fastify.get("/load", async (request, reply) => {
       replaceFilePaths(document.documentElement.innerHTML, manifest)
     ),
     availableCommands: availableCommands(),
-    testName: expect.getState().currentTestName,
   };
 });
 

--- a/test-app/src/testingUtil.js
+++ b/test-app/src/testingUtil.js
@@ -97,6 +97,7 @@ fastify.get("/load", async (request, reply) => {
       replaceFilePaths(document.documentElement.innerHTML, manifest)
     ),
     availableCommands: availableCommands(),
+    testName: expect.getState().currentTestName,
   };
 });
 

--- a/test-runner/src/App.js
+++ b/test-runner/src/App.js
@@ -40,15 +40,6 @@ function App() {
           setInnerHTML={setInnerHTML}
         />
         <button onClick={() => axios.post("/stop")}>Stop Test</button>
-        <button
-          onClick={() =>
-            axios.post("/reset").then((response) => {
-              setInnerHTML(response.data.html);
-            })
-          }
-        >
-          Reset Test
-        </button>
       </div>
       <IFrame className="app">{innerHTML}</IFrame>
     </div>

--- a/test-runner/src/CommandInput.js
+++ b/test-runner/src/CommandInput.js
@@ -46,7 +46,7 @@ function CommandInput({ setInnerHTML, availableCommands }) {
                 line:
                   response.data.error.lineNumber +
                   readOnlyEditor.content.split("\n").length,
-                error: response.data.error,
+                message: response.data.error,
               },
             ]
           : [...readOnlyEditor.errors],
@@ -73,7 +73,7 @@ function CommandInput({ setInnerHTML, availableCommands }) {
       );
     });
   }, [setInnerHTML, setReadOnlyEditor, readOnlyEditor]);
-
+  console.log(readOnlyEditor.errors);
   return (
     <>
       <Editor

--- a/test-runner/src/CommandInput.js
+++ b/test-runner/src/CommandInput.js
@@ -3,12 +3,25 @@ import axios from "axios";
 
 import Editor, { useEditor } from "./Editor";
 
+const HISTORY_KEY = "HISTORY";
+
 function CommandInput({ setInnerHTML, availableCommands }) {
   // const readOnlyEditorProps = useEditor();
   // const editorProps = useEditor();
   // const { codeMirrorRef, codeHistory, appendToHistory, setText } = editorProps;
   const [commandHistory, setCommandHistory] = useState([]);
+  const [readOnlyEditor, setReadOnlyEditor] = useState({
+    content: "",
+    errors: [],
+  });
   const [editorValue, setEditorValue] = useState("");
+
+  // useEffect(() => {
+  //   const existingHistory = window.localStorage.setItem(
+  //     HISTORY_KEY,
+  //     commandHistory
+  //   );
+  // }, [commandHistory]);
 
   const submit = useCallback(() => {
     axios.post("/command", { command: editorValue }).then((response) => {
@@ -20,30 +33,50 @@ function CommandInput({ setInnerHTML, availableCommands }) {
           error: response.data.error,
         },
       ]);
+      setReadOnlyEditor({
+        content: readOnlyEditor.content + editorValue + "\n",
+        errors: response.data.error
+          ? [
+              ...readOnlyEditor.errors,
+              {
+                line:
+                  response.data.lineNumber +
+                  readOnlyEditor.content.split("\n").length,
+                error: response.data.error,
+              },
+            ]
+          : [...readOnlyEditor.errors],
+      });
       setEditorValue("");
     });
-  }, [commandHistory, setCommandHistory, setInnerHTML, editorValue]);
-  const errors = useMemo(
-    () =>
-      commandHistory.reduce(
-        (acc, history) => {
-          acc.line += 1;
-          if (history.error) {
-            acc.errors.push({ message: history.error, line: acc.line });
-          }
-          return acc;
-        },
-        { line: 0, errors: [] }
-      ).errors,
-    [commandHistory]
-  );
-
+  }, [
+    commandHistory,
+    setCommandHistory,
+    setInnerHTML,
+    editorValue,
+    readOnlyEditor,
+  ]);
+  // const errors = useMemo(
+  //   () =>
+  //     commandHistory.reduce(
+  //       (acc, history) => {
+  //         acc.line += 1;
+  //         if (history.error) {
+  //           acc.errors.push({ message: history.error, line: acc.line });
+  //         }
+  //         return acc;
+  //       },
+  //       { line: 0, errors: [] }
+  //     ).errors,
+  //   [commandHistory]
+  // );
+  console.log(readOnlyEditor);
   return (
     <>
       <Editor
-        content={commandHistory.map((history) => history.command).join("\n")}
+        content={readOnlyEditor.content}
         availableCommands={availableCommands}
-        errors={errors}
+        errors={readOnlyEditor.errors}
         readonly
       />
       <Editor
@@ -51,7 +84,7 @@ function CommandInput({ setInnerHTML, availableCommands }) {
         onContentChange={setEditorValue}
         availableCommands={availableCommands}
         submit={submit}
-        commandHistory={commandHistory.map((history) => history.command)}
+        commandHistory={commandHistory}
       />
       <button onClick={submit}>Submit</button>
     </>

--- a/test-runner/src/Editor.js
+++ b/test-runner/src/Editor.js
@@ -126,7 +126,7 @@ const errorState = StateField.define({
     return RangeSet.empty;
   },
   update(value, transaction) {
-    // value = value.map(transaction.changes);
+    value = value.map(transaction.changes);
 
     const errorEffects = transaction.effects.filter((error) =>
       error.is(errorEffect)

--- a/test-runner/src/ErrorBoundary.js
+++ b/test-runner/src/ErrorBoundary.js
@@ -1,0 +1,21 @@
+import React from "react";
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return <h1>An error occured loading the coding editor.</h1>;
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
This change adds three things:
1) It persists the command history, and the ctrl-up ctrl-down command history in local storage.
2) It updates the command history code window to show all of the previous commands with breaks between browser refreshes and test restarts.
3) It adds an error boundary in case the code windows crash. This can happen when the local storage state gets corrupted. We also add a button to clear the local storage state.