### PR TITLE
Enable extra commands and styling.

### DIFF
--- a/test-app/src/App.js
+++ b/test-app/src/App.js
@@ -23,7 +23,7 @@ function App() {
       </header>
       <div>Counter: {counter}</div>
       <button onClick={() => setCounter(counter + 1)}>Increment counter</button>
-      <div>Delayed update: {delayedUpdate}</div>
+      <div className="test-style">Delayed update: {delayedUpdate}</div>
       <button
         onClick={() =>
           setTimeout(() => {

--- a/test-app/src/App.test.js
+++ b/test-app/src/App.test.js
@@ -1,11 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import App from "./App";
-import { start } from "./testingUtil";
+import { debugTest } from "./testingUtil";
 
-test("renders learn react link", async () => {
-  await start(() => {
-    render(<App />);
-  });
+debugTest("renders learn react link", async () => {
+  render(<App />);
   const linkElement = screen.getByText(/learn react/i);
   expect(linkElement).toBeInTheDocument();
 });

--- a/test-app/src/commandParser.js
+++ b/test-app/src/commandParser.js
@@ -27,7 +27,7 @@ function refresh() {
   // This is a no op just to refresh the page
 }
 
-const IDENTIFIER_MAP = {
+let IDENTIFIER_MAP = {
   screen,
   expect,
   fireEvent,
@@ -35,6 +35,9 @@ const IDENTIFIER_MAP = {
   within,
   highlight,
   refresh,
+};
+export const registerCommands = (commands) => {
+  IDENTIFIER_MAP = { ...IDENTIFIER_MAP, ...commands };
 };
 
 export const availableCommands = () => {

--- a/test-app/src/setupTests.js
+++ b/test-app/src/setupTests.js
@@ -3,10 +3,12 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
-import { stop, debuggerSetup } from "./testingUtil";
+import { registerCommands } from "./commandParser";
+import { registerStyling } from "./testingUtil";
 
-debuggerSetup();
-
-afterAll(() => {
-  return stop();
+registerStyling("static/css/test.css");
+registerCommands({
+  test: () => {
+    console.log("test command");
+  },
 });


### PR DESCRIPTION
This adds the ability to extend the testing library with specific commands and styling.

It also creates a wrapper to Jest's `test` function called `debugTest` which handles the setup and tear down of the test. 