### PR TITLE
Add more command types

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ import {
   setup,
 } from "react-testing-visualizer";
 import path from "path";
+import { expect } from "@jest/globals";
+import { screen, within, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 setup(path.join(__dirname, "..", "build")); // This should point to wherever your built assets are
+
+registerCommands({ screen, within, fireEvent, userEvent, expect }); // This should include any commands you want to run. See the custom command section below.
 ```
 
 ## Debugging a test
@@ -33,7 +38,7 @@ import { debugTest } from "react-testing-visualizer";
 Then replace `test` with `debugTest`. For example:
 
 ```javascript
-import { render, screen, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import App from "./App";
 import { debugTest } from "react-testing-visualizer";
 
@@ -56,15 +61,20 @@ https://user-images.githubusercontent.com/3885236/152245374-0a60bae9-974e-4d02-9
 From this interface you can run commands to interact with your test. Specifically, you can run the following built in commands:
 
 ```
-screen
-within
-userEvent
-fireEvent
 highlight
 refresh
 ```
 
-The first four are commands defined by Testing Library. Highlight and refresh are defined by Testing Library Visualizer. `highlight` takes a HTML element(s) and draws boxes around them. This is a good way to understand what components you're selecting with your testing library commands. `refresh` asks for the latest state of the application. This is useful when an operation might take some time to complete, and you want to see the most up to date version of the component you're testing.
+And if you configured your test setup as specified above you'll have access to:
+
+```
+screen
+within
+userEvent
+fireEvent
+```
+
+Highlight and refresh are defined by Testing Library Visualizer. `highlight` takes a HTML element(s) and draws boxes around them. This is a good way to understand what components you're selecting with your testing library commands. `refresh` asks for the latest state of the application. This is useful when an operation might take some time to complete, and you want to see the most up to date version of the component you're testing.
 
 Using these commands you can build up a full test interactively.
 

--- a/package/commandParser.js
+++ b/package/commandParser.js
@@ -25,11 +25,6 @@ function refresh() {
 }
 
 let IDENTIFIER_MAP = {
-  // screen,
-  // expect,
-  // fireEvent,
-  // userEvent,
-  // within,
   highlight,
   refresh,
 };

--- a/package/commandParser.js
+++ b/package/commandParser.js
@@ -1,6 +1,3 @@
-import { expect } from "@jest/globals";
-import { screen, within, fireEvent } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 const util = require("util");
 
 let acorn = require("acorn");
@@ -28,11 +25,11 @@ function refresh() {
 }
 
 let IDENTIFIER_MAP = {
-  screen,
-  expect,
-  fireEvent,
-  userEvent,
-  within,
+  // screen,
+  // expect,
+  // fireEvent,
+  // userEvent,
+  // within,
   highlight,
   refresh,
 };

--- a/package/commandParser.test.js
+++ b/package/commandParser.test.js
@@ -8,7 +8,7 @@ import { screen, within, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 beforeAll(() => {
-  registerCommands({ screen, within, fireEvent, userEvent });
+  registerCommands({ screen, within, fireEvent, userEvent, expect });
 });
 
 test("parses simple command", async () => {

--- a/package/commandParser.test.js
+++ b/package/commandParser.test.js
@@ -3,6 +3,13 @@ import { render } from "@testing-library/react";
 import { consoleLogQueue, debuggerSetup } from "./testingUtil";
 import { runCommand, availableCommands } from "./commandParser";
 import { useState } from "react";
+import { expect } from "@jest/globals";
+import { screen, within, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+beforeAll(() => {
+  registerCommands({ screen, within, fireEvent, userEvent });
+});
 
 test("parses simple command", async () => {
   render(<>Hello World</>);

--- a/package/commandParser.test.js
+++ b/package/commandParser.test.js
@@ -96,3 +96,27 @@ test("reports warnings", async () => {
     ).toEqual(expect.stringMatching(/not wrapped in act/g));
   });
 });
+
+test("can set variables", async () => {
+  render(<>Hello World</>);
+
+  expect(
+    (
+      await runCommand(`
+    const element = screen.getByText(/Hello/);
+    expect(element).toBeInTheDocument();`)
+    ).error
+  ).toBeNull();
+});
+
+test("can access arrays", async () => {
+  render(<>Hello World</>);
+
+  expect(
+    (
+      await runCommand(`
+    const element = screen.getAllByText(/Hello/)[0];
+    expect(element).toBeInTheDocument();`)
+    ).error
+  ).toBeNull();
+});

--- a/package/package.json
+++ b/package/package.json
@@ -17,10 +17,6 @@
     "testing-library"
   ],
   "dependencies": {
-    "@testing-library/dom": "^8.11.1",
-    "@testing-library/jest-dom": "^5.16.1",
-    "@testing-library/react": "^12.1.2",
-    "@testing-library/user-event": "^13.5.0",
     "acorn": "^8.7.0",
     "fastify": "^3.25.0",
     "fastify-static": "^4.5.0"
@@ -39,6 +35,10 @@
     "babel-jest": "^27.4.6",
     "jest": "^27.4.7",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "@testing-library/dom": "^8.11.1",
+    "@testing-library/jest-dom": "^5.16.1",
+    "@testing-library/react": "^12.1.2",
+    "@testing-library/user-event": "^13.5.0"
   }
 }

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-testing-visualizer",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A companion library to react-testing-library to help write, debug, and visualize your tests.",
   "main": "index.js",
   "type": "module",

--- a/package/testingUtil.js
+++ b/package/testingUtil.js
@@ -31,7 +31,7 @@ export const debugTest = async (name, fn) => {
       try {
         await debuggerSetup(async () => {
           await start(() => {
-            evaluator = Evaluator();
+            evaluator = new Evaluator();
             fn();
           });
         });

--- a/package/testingUtil.test.js
+++ b/package/testingUtil.test.js
@@ -16,6 +16,6 @@ test("replace assets properly", async () => {
   const html = `<body><img src="logo.svg" class="App-logo" alt="logo"></body>`;
 
   expect(replaceFilePaths(html, assetManifest)).toEqual(
-    `<body><img src="/static/media/logo.6ce24c58023cc2f8fd88fe9d219db6c6.svg" class="App-logo" alt="logo"></body>`
+    `<body><img src="/assets/static/media/logo.6ce24c58023cc2f8fd88fe9d219db6c6.svg" class="App-logo" alt="logo"></body>`
   );
 });

--- a/test-runner/src/Editor.js
+++ b/test-runner/src/Editor.js
@@ -239,6 +239,8 @@ const setText = (codeMirrorRef, content) => {
 
 const setErrors = (codeMirrorRef, errors) => {
   if (!codeMirrorRef.current || !errors) return;
+  console.log(errors);
+
   const existingErrorState = codeMirrorRef.current.state.field(errorState);
 
   const existingErrors = [];

--- a/test-runner/src/setupTests.js
+++ b/test-runner/src/setupTests.js
@@ -3,8 +3,13 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
-import { setup } from "react-testing-visualizer";
+import { setup, registerCommands } from "react-testing-visualizer";
 import path from "path";
+import { expect } from "@jest/globals";
+import { screen, within, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+registerCommands({ screen, within, fireEvent, userEvent });
 
 setup(path.join(__dirname, "..", "build"));
 

--- a/test-runner/src/setupTests.js
+++ b/test-runner/src/setupTests.js
@@ -9,7 +9,7 @@ import { expect } from "@jest/globals";
 import { screen, within, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-registerCommands({ screen, within, fireEvent, userEvent });
+registerCommands({ screen, within, fireEvent, userEvent, expect });
 
 setup(path.join(__dirname, "..", "build"));
 


### PR DESCRIPTION
This change enables users to declare and reference variables, and to reference arrays.

We also update the available commands. If we define commands in the package itself, we might pull in the wrong version. It's best to let the user define what commands they want access to.