### PR TITLE
Fix command history reset

### DIFF
--- a/test-runner/src/Editor.js
+++ b/test-runner/src/Editor.js
@@ -96,15 +96,16 @@ const commandHistoryState = StateField.define({
     return { index: 0, commandHistory: [] };
   },
   update(value, transaction) {
+    let newValue = value;
     for (const effect of transaction.effects) {
       if (effect.is(updateCommandHistoryEffect)) {
-        return { ...value, commandHistory: effect.value.commandHistory };
+        newValue = { ...newValue, commandHistory: effect.value.commandHistory };
       }
       if (effect.is(updateHistoryIndexEffect)) {
-        return { ...value, index: effect.value.index };
+        newValue = { ...newValue, index: effect.value.index };
       }
     }
-    return value;
+    return newValue;
   },
 });
 
@@ -212,8 +213,12 @@ const underlineTheme = EditorView.baseTheme({
 
 const setCodeHistory = (codeMirrorRef, commandHistory) => {
   if (!codeMirrorRef.current) return;
+  console.log("settingCodeHistory");
   codeMirrorRef.current.dispatch({
-    effects: updateCommandHistoryEffect.of({ commandHistory }),
+    effects: [
+      updateCommandHistoryEffect.of({ commandHistory }),
+      updateHistoryIndexEffect.of({ index: 0 }),
+    ],
   });
 };
 

--- a/test-runner/src/Editor.test.js
+++ b/test-runner/src/Editor.test.js
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import Editor from "./Editor";
 import userEvent from "@testing-library/user-event";
-import { debugTest } from "react-testing-visualizer";
+
 const EditorWrapper = (props) => {
   const [content, setContent] = useState("");
 

--- a/test-runner/src/Editor.test.js
+++ b/test-runner/src/Editor.test.js
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import Editor from "./Editor";
 import userEvent from "@testing-library/user-event";
-
+import { debugTest } from "react-testing-visualizer";
 const EditorWrapper = (props) => {
   const [content, setContent] = useState("");
 
@@ -33,4 +33,27 @@ test("can render error tooltip in editor", async () => {
   );
   await user.hover(await screen.findByText(/hello/));
   expect(await screen.findByText(/This is an error/)).toBeInTheDocument();
+});
+
+test("command history is reset when changed", async () => {
+  const user = userEvent.setup();
+
+  const { rerender } = render(<EditorWrapper commandHistory={["old"]} />);
+
+  await user.click(screen.getByRole("textbox"));
+  await user.keyboard("[ControlLeft>][ArrowUp][/ControlLeft]");
+
+  await expect(await screen.findByText(/old/)).toBeInTheDocument();
+
+  rerender(
+    <EditorWrapper
+      errors={[{ message: "This is an error", line: 1 }]}
+      commandHistory={["new", "old"]}
+    />
+  );
+
+  await user.click(screen.getByRole("textbox"));
+  await user.keyboard("[ControlLeft>][ArrowUp][/ControlLeft]");
+
+  await expect(await screen.findByText(/new/)).toBeInTheDocument();
 });


### PR DESCRIPTION
Fixes: #17 

Currently when using ctrl+up/down to navigate history the buffer doesn't reset when new items are added. We want this to act more like the terminal does. After a command is run in the terminal your location in the buffer is reset to the most recent command. This change implements that. Now:
```
ctrl+up
<submit>
ctrl+up
```
Puts what was just submitted into the buffer instead of what was in the buffer two above the most recent command.