### PR TITLE
build: make dependabot use proper commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope


### PR DESCRIPTION
Updates dependabot configuration to bring it inline with what semantic release expects. 