### PR TITLE
build: reduce the engine requirement (14 should be allowed)

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint src/**.js --max-warnings=0 && prettier src/**.js --check"
   },
   "engines": {
-    "node": ">=15"
+    "node": ">=14"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
A user couldn't pull in the library because they are on node 14. We just need above node 12 (doesn't look like 13 exists) so we're allowing anything >=14 now.