### PR TITLE
fix: move frontend out of lib directory

### DIFF
--- a/package/src/testingUtil.js
+++ b/package/src/testingUtil.js
@@ -130,14 +130,14 @@ function addStyleLinks(html) {
 }
 
 fastify.register(fastifyStatic, {
-  root: path.join(__dirname, "build"),
+  root: path.join(__dirname, "..", "build"),
   prefix: "/", // optional: default '/'
   wildcard: true,
   decorateReply: false,
 });
 
 fastify.get("/", async (request, reply) => {
-  return reply.sendFile("index.html", path.join(__dirname, "build"));
+  return reply.sendFile("index.html", path.join(__dirname, "..", "build"));
 });
 
 fastify.get("/load", async (request, reply) => {
@@ -200,7 +200,7 @@ export const start = async (setupFunction) => {
     await getCssFiles();
     await setupFunction();
     await fastify.listen(3001);
-    console.log("Debug server is running, open at 127.0.0.1:3001");
+    console.log("Debug server is running, open at localhost:3001");
     while (isListening) {
       await sleep(50);
     }

--- a/test-app/package-lock.json
+++ b/test-app/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "test-app",
       "version": "0.1.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.16.1",
@@ -22,13 +23,10 @@
       }
     },
     "../package": {
-      "version": "0.1.0",
+      "name": "react-testing-visualizer",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
-        "@testing-library/dom": "^8.11.1",
-        "@testing-library/jest-dom": "^5.16.1",
-        "@testing-library/react": "^12.1.2",
-        "@testing-library/user-event": "^13.5.0",
         "acorn": "^8.7.0",
         "fastify": "^3.25.0",
         "fastify-static": "^4.5.0"
@@ -38,10 +36,22 @@
         "@babel/core": "^7.16.12",
         "@babel/plugin-transform-react-jsx": "^7.16.7",
         "@babel/preset-env": "^7.16.11",
+        "@testing-library/dom": "^8.11.1",
+        "@testing-library/jest-dom": "^5.16.1",
+        "@testing-library/react": "^12.1.2",
+        "@testing-library/user-event": "^13.5.0",
         "babel-jest": "^27.4.6",
+        "eslint": "^8.8.0",
+        "eslint-config-react-app": "^7.0.0",
         "jest": "^27.4.7",
+        "prettier": "2.5.1",
         "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react-dom": "^17.0.2",
+        "semantic-release": "^19.0.2",
+        "webpack-cli": "^4.9.2"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4952,7 +4962,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -6291,8 +6300,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -9228,7 +9236,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^27.4.0",
         "jest-serializer": "^27.4.0",
@@ -10477,7 +10484,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -13058,7 +13064,6 @@
         "eslint-webpack-plugin": "^3.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.0.0",
-        "fsevents": "^2.3.2",
         "html-webpack-plugin": "^5.5.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.4.3",
@@ -13432,9 +13437,6 @@
       "version": "2.63.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
       "integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
-      "dependencies": {
-        "fsevents": "~2.3.2"
-      },
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -25212,11 +25214,16 @@
         "@testing-library/user-event": "^13.5.0",
         "acorn": "^8.7.0",
         "babel-jest": "^27.4.6",
+        "eslint": "^8.8.0",
+        "eslint-config-react-app": "^7.0.0",
         "fastify": "^3.25.0",
         "fastify-static": "^4.5.0",
         "jest": "^27.4.7",
+        "prettier": "2.5.1",
         "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react-dom": "^17.0.2",
+        "semantic-release": "^19.0.2",
+        "webpack-cli": "^4.9.2"
       }
     },
     "readable-stream": {

--- a/test-runner/build.sh
+++ b/test-runner/build.sh
@@ -1,2 +1,2 @@
 npm run build
-cp -r build ../package/lib
+cp -r build ../package/

--- a/test-runner/package-lock.json
+++ b/test-runner/package-lock.json
@@ -35,7 +35,7 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-scripts": "^5.0.0",
-        "react-testing-visualizer": "^0.1.8",
+        "react-testing-visualizer": "^1.0.1",
         "web-vitals": "^2.1.2"
       },
       "devDependencies": {
@@ -13623,16 +13623,16 @@
       }
     },
     "node_modules/react-testing-visualizer": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/react-testing-visualizer/-/react-testing-visualizer-0.1.8.tgz",
-      "integrity": "sha512-Rum5pRmMa6/2p+0rpo3KFJzCGspO0Ht45ivNA2VB2eEJonnqy9zKM7cJ5DejMN8TuPKuR5JkFp5JpSgZvG4Ntw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-testing-visualizer/-/react-testing-visualizer-1.0.1.tgz",
+      "integrity": "sha512-L5SXKPf0ge1nWRdoJ8X7YJh0r1c+njkiwRZPoeBVK5Oxn8n627WFb2hnJbz2utzifg4mCyBgTDu4F4wJQF1H+g==",
       "dependencies": {
         "acorn": "^8.7.0",
         "fastify": "^3.25.0",
         "fastify-static": "^4.5.0"
       },
       "engines": {
-        "node": ">=15"
+        "node": ">=14"
       }
     },
     "node_modules/readable-stream": {
@@ -26261,9 +26261,9 @@
       }
     },
     "react-testing-visualizer": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/react-testing-visualizer/-/react-testing-visualizer-0.1.8.tgz",
-      "integrity": "sha512-Rum5pRmMa6/2p+0rpo3KFJzCGspO0Ht45ivNA2VB2eEJonnqy9zKM7cJ5DejMN8TuPKuR5JkFp5JpSgZvG4Ntw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-testing-visualizer/-/react-testing-visualizer-1.0.1.tgz",
+      "integrity": "sha512-L5SXKPf0ge1nWRdoJ8X7YJh0r1c+njkiwRZPoeBVK5Oxn8n627WFb2hnJbz2utzifg4mCyBgTDu4F4wJQF1H+g==",
       "requires": {
         "acorn": "^8.7.0",
         "fastify": "^3.25.0",

--- a/test-runner/package.json
+++ b/test-runner/package.json
@@ -30,7 +30,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "^5.0.0",
-    "react-testing-visualizer": "^0.1.8",
+    "react-testing-visualizer": "^1.0.1",
     "web-vitals": "^2.1.2"
   },
   "proxy": "http://localhost:3001",


### PR DESCRIPTION
Currently our frontend is built and moved to the lib/build directory in the package. Then the
package is built and the files are compiled to the lib directory. This overwrites the frontend. Now
the frontend lives in the build directory and the other files live in the lib directory.