### PR TITLE
fix(updating name of package): change name to testing-library-visualizer

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-testing-visualizer",
+  "name": "testing-library-visualizer",
   "version": "0.1.9",
   "description": "A companion library to react-testing-library to help write, debug, and visualize your tests.",
   "exports": "./lib/index.js",


### PR DESCRIPTION
This updates the name of this package because react-testing-visualizer is too narrow. This tool can
be used to visualize tests with any of the testing-library suite.